### PR TITLE
Add common project documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to this repository
+
+This project is not actively seeking external contributions. If you raise an issue or open a pull request, we will do
+our best to respond to it, but we can’t guarantee that we will fix or merge anything.
+
+If you’re thinking about putting a lot of work into a pull request, and would like to get a better idea of whether we’d
+consider merging it, we advise that you first open a GitHub issue so that we can talk about it.

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,3 +1,5 @@
+# The MIT License (MIT)
+
 Copyright (C) 2023 Crown Copyright (The National Archives)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# DS Caselaw Frontend
-## Introduction
+# The National Archives: Find Case Law
 
-This repository contains shared SASS and JS for the [Find caselaw service](https://caselaw.nationalarchives.gov.uk/), it's used across the Editor UI[Editor UI](https://github.com/nationalarchives/ds-caselaw-editor-ui) and the [Public UI](https://github.com/nationalarchives/ds-caselaw-public-ui).
+This repository is part of the [Find Case Law](https://caselaw.nationalarchives.gov.uk/) project at [The National Archives](https://www.nationalarchives.gov.uk/). For more information on the project, check [the documentation](https://github.com/nationalarchives/ds-find-caselaw-docs).
+
+# Frontend CSS
+
+This repository contains shared SASS and JS for the Find Case Law service. It's used across the Editor UI[Editor UI](https://github.com/nationalarchives/ds-caselaw-editor-ui) and the [Public UI](https://github.com/nationalarchives/ds-caselaw-public-ui).
 
 ## Contents
 


### PR DESCRIPTION
Add `CONTRIBUTING.md` to match the rest of the project, make the `LICENSE` file `LICENSE.md` and add a header for consistency, and give `README.md` the common header to help with orientation.