### PR TITLE
Move common colours to the shared frontend repository

### DIFF
--- a/src/includes/variables/_colours.scss
+++ b/src/includes/variables/_colours.scss
@@ -1,0 +1,28 @@
+$color__almost-black: #121212;
+$color__light-pink: #fbe2bc;
+$color__white: #fff;
+$color__light-grey: #efefef;
+$color__dark-blue: #134571;
+$color__grey: #ddd;
+$color__dark-grey: #555;
+$color__black: #000;
+$color__highlight-blue: #0066cc;
+$color__yellow: #ffb952;
+$color__aqua-blue: #037091;
+
+$color__success: #336600;
+$color__information: #96d2f8;
+$color__failure: #cc3300;
+
+$color__green: #3bb300;
+$color__red: #ff0000;
+
+$color__link-blue: $color__aqua-blue;
+$color__link-blue-hover: $color__dark-blue;
+$color__link-blue-focus: $color__dark-blue;
+$color__link-blue-visited: #4c2c92;
+$color__link-blue-active: #1e1e2a;
+
+$color__focus-blue-outline: #1d70b8;
+$color__cta-background: $color__aqua-blue;
+$color__cta-background-hover: $color__dark-blue;


### PR DESCRIPTION
EUI and PUI share a common pallete of colours for the site and some elements. Aside from EUI-specific colours for document state, move all of these to the shared repository so they're always kept in unison.