### PR TITLE
Add stylelint to start enforcing SCSS code conventions, not just style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,19 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
 
+  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
+    rev: "4200758"
+    hooks:
+      - id: stylelint
+        additional_dependencies:
+          [
+            "stylelint@15.11.0",
+            "stylelint-config-standard-scss@11.0.0",
+            "stylelint-config-clean-order@5.2.0",
+            "stylelint-selector-bem-pattern@3.0.1",
+          ]
+        args: ["--fix"]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": [
+    "stylelint-config-standard-scss",
+    "stylelint-config-clean-order"
+  ],
+  "plugins": [
+    "stylelint-selector-bem-pattern"
+  ],
+  "rules": {
+    "block-no-empty": null,
+    "property-no-vendor-prefix": null,
+    "value-keyword-case": null,
+    "scss/dollar-variable-empty-line-before": null,
+    "scss/double-slash-comment-empty-line-before": null,
+    "selector-class-pattern": null,
+    "plugin/selector-bem-pattern": {
+      "preset": "bem"
+    }
+  }
+}

--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -1,111 +1,13 @@
 @import "./mixins";
-
-.judgment {
-  max-width: 90%;
-  margin: auto;
-  margin-bottom: calc($spacer__unit * 2);
-  font-size: 1.2rem;
-  line-height: 1.3;
-  font-family: $font__serif;
-
-  @media (min-width: $grid__breakpoint-medium) {
-    font-size: 1.1rem;
-    max-width: 40rem;
-  }
-
-  @media (min-width: $grid__breakpoint-medium) {
-    font-size: 1rem;
-    max-width: 46rem;
-  }
-
-  img {
-    max-width: 100vw;
-  }
-
-  table {
-    border-collapse: collapse;
-    width: 100%;
-
-    &.pr-two-column {
-      table-layout: fixed;
-      width: 100%;
-
-      td:first-child {
-        width: 80%;
-        padding-left: 20%;
-        padding-right: 0;
-
-        @media (max-width: $grid__breakpoint-small) {
-          padding: 0 1rem;
-        }
-      }
-
-      td:last-child {
-        width: 20%;
-        padding: 0;
-        overflow-wrap: anywhere;
-
-        @media (max-width: $grid__breakpoint-small) {
-          white-space: nowrap;
-          padding-right: 1rem;
-        }
-      }
-    }
-  }
-
-  td {
-    padding-left: 1em;
-    padding-right: 1em;
-  }
-
-  td > p:first-child {
-    margin-top: 0;
-  }
-
-  td > p:last-child {
-    margin-bottom: 0;
-  }
-}
-
+/* stylelint-disable no-descending-specificity */
 .judgment-header {
-  padding-top: $spacer__unit * 3;
+  padding-top: $spacer-unit * 3;
 
   table {
     td {
       border-color: transparent;
     }
   }
-
-  // START – Thi is a fix to correct the alignment of the crest image so that it is centred.
-  // Refer to NCN [2022] EWCA Crim 985 as an example.
-
-  table.crest-alignment-fix {
-    margin-top: 1rem;
-
-    td {
-      border-color: transparent;
-      width: 67%;
-      padding-left: 0;
-
-      &:last-child {
-        padding: 0;
-        width: 33%;
-        text-align: right;
-      }
-
-      img {
-        display: block;
-        padding-left: 57%;
-        margin: 1rem auto;
-      }
-    }
-
-    .judgment-header__neutral-citation {
-      text-align: left;
-    }
-  }
-
-  // ENDS
 
   &__logo {
     img {
@@ -114,13 +16,9 @@
     }
   }
 
-  p {
-    margin: 0 0 calc($spacer__unit / 2) 0;
-  }
-
   &__neutral-citation {
-    text-decoration: underline;
     text-align: right;
+    text-decoration: underline;
 
     span.ncn-nowrap {
       white-space: nowrap;
@@ -132,10 +30,45 @@
     }
   }
 
+  // START – Thi is a fix to correct the alignment of the crest image so that it is centred.
+  // Refer to NCN [2022] EWCA Crim 985 as an example.
+
+  table.crest-alignment-fix {
+    margin-top: 1rem;
+
+    td {
+      width: 67%;
+      padding-left: 0;
+      border-color: transparent;
+
+      &:last-child {
+        width: 33%;
+        padding: 0;
+        text-align: right;
+      }
+
+      img {
+        display: block;
+        margin: 1rem auto;
+        padding-left: 57%;
+      }
+    }
+
+    .judgment-header__neutral-citation {
+      text-align: left;
+    }
+  }
+
+  // ENDS
+
+  p {
+    margin: 0 0 calc($spacer-unit / 2) 0;
+  }
+
   &__case-number {
-    padding-top: $spacer__unit;
-    text-decoration: underline;
+    padding-top: $spacer-unit;
     text-align: right;
+    text-decoration: underline;
 
     h1 {
       font-size: 1rem;
@@ -148,23 +81,23 @@
   }
 
   &__address {
-    padding-top: $spacer__unit;
+    padding-top: $spacer-unit;
     font-style: normal;
-    text-decoration: underline;
     text-align: right;
+    text-decoration: underline;
   }
 
   &__date {
-    padding-top: $spacer__unit;
+    padding-top: $spacer-unit;
     font-style: normal;
-    text-decoration: underline;
     text-align: right;
+    text-decoration: underline;
   }
 
   &__before {
-    padding-top: $spacer__unit;
-    text-align: center;
+    padding-top: $spacer-unit;
     font-weight: bold;
+    text-align: center;
 
     h2 {
       font-size: 1rem;
@@ -173,27 +106,8 @@
 
   &__between {
     h2 {
-      font-size: $spacer__unit;
+      font-size: $spacer-unit;
       text-align: center;
-    }
-  }
-
-  @media (min-width: $grid__breakpoint-medium) {
-    &__party {
-      @include three-columns($spacer__unit);
-      font-weight: bold;
-    }
-
-    &__and-separator {
-      text-align: center;
-      font-weight: bold;
-
-      &--between {
-        text-align: center;
-        font-weight: bold;
-        margin-top: $spacer__unit;
-        margin-bottom: $spacer__unit;
-      }
     }
   }
 
@@ -202,14 +116,14 @@
   }
 
   &__queens-counsel {
-    @media (min-width: $grid__breakpoint-medium) {
+    @media (min-width: $grid-breakpoint-medium) {
       ul {
         padding: 0;
       }
 
       li {
-        list-style: none;
         text-align: center;
+        list-style: none;
 
         span {
           font-weight: bold;
@@ -241,17 +155,105 @@
   &__pr-left {
     text-align: left !important;
   }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    &__party {
+      @include three-columns($spacer-unit);
+
+      font-weight: bold;
+    }
+
+    &__and-separator {
+      font-weight: bold;
+      text-align: center;
+
+      &--between {
+        margin-top: $spacer-unit;
+        margin-bottom: $spacer-unit;
+        font-weight: bold;
+        text-align: center;
+      }
+    }
+  }
+}
+
+.judgment {
+  max-width: 90%;
+  margin: auto;
+  margin-bottom: calc($spacer-unit * 2);
+
+  font-family: $font-serif;
+  font-size: 1.2rem;
+  line-height: 1.3;
+
+  img {
+    max-width: 100vw;
+  }
+
+  td {
+    padding-right: 1em;
+    padding-left: 1em;
+  }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+
+    &.pr-two-column {
+      table-layout: fixed;
+      width: 100%;
+
+      td:first-child {
+        width: 80%;
+        padding-right: 0;
+        padding-left: 20%;
+
+        @media (max-width: $grid-breakpoint-small) {
+          padding: 0 1rem;
+        }
+      }
+
+      td:last-child {
+        width: 20%;
+        padding: 0;
+        overflow-wrap: anywhere;
+
+        @media (max-width: $grid-breakpoint-small) {
+          padding-right: 1rem;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+
+  td > p:first-child {
+    margin-top: 0;
+  }
+
+  td > p:last-child {
+    margin-bottom: 0;
+  }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    max-width: 40rem;
+    font-size: 1.1rem;
+  }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    max-width: 46rem;
+    font-size: 1rem;
+  }
 }
 
 .judgment-body {
   table {
-    border: 1px solid $color__almost-black;
-    margin: 1rem auto;
     table-layout: auto;
     width: 100%;
+    margin: 1rem auto;
+    border: 1px solid $color-almost-black;
 
     td {
-      border: 1px solid $color__almost-black;
+      border: 1px solid $color-almost-black;
     }
   }
 
@@ -265,23 +267,23 @@
   }
 
   &__number {
-    @media (max-width: $grid__breakpoint-medium) {
-      padding-right: $spacer__unit;
-    }
-
     &:target {
-      animation-duration: 1.5s;
       animation-name: emphasis-border;
+      animation-duration: 1.5s;
 
       + .judgment-body__text {
-        animation-duration: 1.5s;
         animation-name: emphasis;
+        animation-duration: 1.5s;
       }
+    }
+
+    @media (max-width: $grid-breakpoint-medium) {
+      padding-right: $spacer-unit;
     }
   }
 
   &__section {
-    @media (max-width: $grid__breakpoint-medium) {
+    @media (max-width: $grid-breakpoint-medium) {
       > div {
         display: inline;
 
@@ -296,24 +298,22 @@
           &::after {
             content: " ";
             display: block;
-            margin-bottom: $spacer__unit;
+            margin-bottom: $spacer-unit;
           }
         }
       }
     }
 
-    @media (min-width: $grid__breakpoint-medium) {
+    @media (min-width: $grid-breakpoint-medium) {
       display: grid;
-      grid-template-columns: 1fr 15fr;
-      grid-template-rows: 1fr;
-      gap: 0 $spacer__unit * 0.5;
-      grid-template-areas: ". .";
+      grid-template: ". ." 1fr / 1fr 15fr;
+      gap: 0 $spacer-unit * 0.5;
     }
   }
 
   &__nested-section {
-    @media (max-width: $grid__breakpoint-medium) {
-      margin-left: $spacer__unit;
+    @media (max-width: $grid-breakpoint-medium) {
+      margin-left: $spacer-unit;
 
       > div {
         display: inline;
@@ -329,23 +329,21 @@
           &::after {
             content: " ";
             display: block;
-            margin-bottom: $spacer__unit;
+            margin-bottom: $spacer-unit;
           }
         }
       }
     }
 
-    @media (min-width: $grid__breakpoint-medium) {
+    @media (min-width: $grid-breakpoint-medium) {
       display: grid;
-      grid-template-columns: 1fr 24fr;
-      grid-template-rows: 1fr;
-      gap: 0 $spacer__unit * 0.5;
-      grid-template-areas: ". .";
+      grid-template: ". ." 1fr / 1fr 24fr;
+      gap: 0 $spacer-unit * 0.5;
     }
   }
 
   &__indent {
-    margin-left: $spacer__unit;
+    margin-left: $spacer-unit;
   }
 
   &__no-margin-top {
@@ -354,28 +352,28 @@
 }
 
 .judgment-download {
-  background-color: $color__almost-black;
-  padding: calc($spacer__unit / 2);
-  color: $color__white;
+  padding: calc($spacer-unit / 2);
+  color: $color-white;
   text-align: center;
+  background-color: $color-almost-black;
 
   &__container {
     margin: auto;
 
-    @media (min-width: $grid__breakpoint-medium) {
+    @media (min-width: $grid-breakpoint-medium) {
       max-width: 40rem;
     }
 
-    @media (min-width: $grid__breakpoint-medium) {
+    @media (min-width: $grid-breakpoint-medium) {
       max-width: 46rem;
     }
   }
 
   &__list {
     display: inline-block;
-    list-style: none;
-    text-align: center;
     padding: 0;
+    text-align: center;
+    list-style: none;
 
     li {
       display: inline-block;
@@ -389,11 +387,14 @@
 
   a {
     @include link-on-dark-bg;
-    background-image: url($fa_download);
+
+    padding: calc($spacer-unit * 0.3);
+    padding-left: calc($spacer-unit * 2);
+
+    background-image: url($fa-download);
     background-repeat: no-repeat;
+    background-position: calc($spacer-unit / 4) calc($spacer-unit / 4);
     background-size: 1rem;
-    background-position: calc($spacer__unit / 4) calc($spacer__unit / 4);
-    padding: calc($spacer__unit * 0.3);
-    padding-left: calc($spacer__unit * 2);
   }
 }
+/* stylelint-enable no-descending-specificity */

--- a/src/includes/_mixins.scss
+++ b/src/includes/_mixins.scss
@@ -20,111 +20,119 @@
   }
 
   h3 {
-    font-size: 1rem;
     margin: 0;
+    font-size: 1rem;
     text-decoration: underline;
   }
 }
 
 @mixin sr-only {
   position: absolute;
-  left: -10000px;
   top: auto;
+  left: -10000px;
+
+  overflow: hidden;
+
   width: 0.125rem;
   height: 0.125rem;
-  overflow: hidden;
 }
 
 @mixin container {
-  padding: 0 $gutter_unit;
+  max-width: $grid-breakpoint-small - ($gutter-unit * 1);
   margin: auto;
+  padding: 0 $gutter-unit;
 
-  max-width: $grid__breakpoint-small - ($gutter_unit * 1);
-
-  @media (min-width: $grid__breakpoint-medium) {
-    max-width: $grid__breakpoint-medium - ($gutter_unit * 1.5);
+  @media (min-width: $grid-breakpoint-medium) {
+    max-width: $grid-breakpoint-medium - ($gutter-unit * 1.5);
   }
 
-  @media (min-width: $grid__breakpoint-large) {
-    max-width: $grid__breakpoint-large - ($gutter_unit * 2);
+  @media (min-width: $grid-breakpoint-large) {
+    max-width: $grid-breakpoint-large - ($gutter-unit * 2);
   }
 
-  @media (min-width: $grid__breakpoint-extra-large) {
-    max-width: $grid__breakpoint-extra-large - ($gutter_unit * 2);
+  @media (min-width: $grid-breakpoint-extra-large) {
+    max-width: $grid-breakpoint-extra-large - ($gutter-unit * 2);
   }
 }
 
 @mixin call-to-action-button {
-  background-color: $color__cta-background;
-  text-decoration: none;
-  font-weight: 700;
-  border: 0;
-  color: $color__white;
-  padding: 1rem 1.3rem;
   display: inline-block;
+
   margin-top: 1em;
+  padding: 1rem 1.3rem;
+
   font-size: 1rem;
+  font-weight: 700;
+  color: $color-white;
+  text-decoration: none;
+
+  background-color: $color-cta-background;
+  border: 0;
 
   &:visited {
-    color: $color__white;
+    color: $color-white;
   }
 
   &:focus,
   &:hover {
     @include focus-default;
-    color: $color__white;
-    background-color: $color__cta-background-hover;
-    outline-color: $color__cta-background-hover;
-    border-color: $color__cta-background-hover;
+
+    color: $color-white;
     text-decoration: underline;
+
+    background-color: $color-cta-background-hover;
+    border-color: $color-cta-background-hover;
+    outline-color: $color-cta-background-hover;
     outline-offset: 0.2rem;
   }
 }
 
 @mixin emphasised-block {
-  padding: $spacer__unit;
-
-  background-color: $color__light-grey;
-  border-left: 0.5rem solid $color__highlight-blue;
+  padding: $spacer-unit;
+  background-color: $color-light-grey;
+  border-left: 0.5rem solid $color-highlight-blue;
 }
 
 @mixin focus-default {
-  outline: 5px solid $color__focus-blue-outline;
-  outline-offset: 0;
   z-index: 999;
+  outline: 5px solid $color-focus-blue-outline;
+  outline-offset: 0;
 }
 
 @mixin link-on-dark-bg {
-  color: $color__white;
+  color: $color-white;
   text-decoration: underline;
 
   &:visited {
-    color: $color__white;
+    color: $color-white;
   }
 
   &:hover {
+    color: $color-white;
     text-decoration: none;
-    color: $color__white;
   }
 
   &:active {
-    color: $color__white;
+    color: $color-white;
   }
 
   &:focus {
     @include focus-default;
-    outline-color: $color__white;
+
+    outline-color: $color-white;
   }
 }
 
-@mixin text_field {
-  border: 2px solid $color__dark-grey;
-  padding: calc($spacer__unit / 2);
-  margin-top: calc($spacer__unit / 2);
-  background-color: $color__white;
+@mixin text-field {
   width: 80%;
-  font-family: $font__open-sans;
+  margin-top: calc($spacer-unit / 2);
+  padding: calc($spacer-unit / 2);
+
+  font-family: $font-open-sans;
   font-size: 1rem;
+
+  background-color: $color-white;
+  border: 2px solid $color-dark-grey;
 
   &:focus {
     @include focus-default;
@@ -132,20 +140,18 @@
 }
 
 @mixin select {
-  font-size: $spacer__unit;
-  color: #444;
-  line-height: 1.3;
-  padding: 0.375rem;
-  margin-top: calc($spacer__unit / 2);
-  margin-bottom: $spacer__unit;
-  width: 80%;
   box-sizing: border-box;
-  border: 2px solid $color__dark-grey;
-  border-radius: 0;
-  -moz-appearance: none;
-  -webkit-appearance: none;
+  width: 80%;
+  margin-top: calc($spacer-unit / 2);
+  margin-bottom: $spacer-unit;
+  padding: 0.375rem;
+
+  font-size: $spacer-unit;
+  line-height: 1.3;
+  color: #444;
+
   appearance: none;
-  background-color: $color__white;
+  background-color: $color-white;
   background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
   background-repeat: no-repeat, repeat;
   background-position:
@@ -154,16 +160,21 @@
   background-size:
     0.65rem auto,
     100%;
+  border: 2px solid $color-dark-grey;
+  border-radius: 0;
 
   &::-ms-expand {
     display: none;
   }
+
   &:hover {
     border-color: #888;
   }
+
   &:focus {
     @include focus-default;
   }
+
   option {
     font-weight: normal;
   }

--- a/src/includes/variables/_colours.scss
+++ b/src/includes/variables/_colours.scss
@@ -1,29 +1,25 @@
-$color__almost-black: #121212;
-$color__light-pink: #fbe2bc;
-$color__white: #fff;
-$color__light-grey: #efefef;
-$color__dark-blue: #134571;
-$color__grey: #ddd;
-$color__dark-grey: #555;
-$color__black: #000;
-$color__highlight-blue: #0066cc;
-$color__yellow: #ffb952;
-$color__aqua-blue: #037091;
-
-$color__success: #336600;
-$color__information: #96d2f8;
-$color__failure: #cc3300;
-
-$color__green: #3bb300;
-$color__red: #ff0000;
-
-$color__link-blue: $color__aqua-blue;
-$color__link-blue-hover: $color__dark-blue;
-$color__link-blue-focus: $color__dark-blue;
-$color__link-blue-visited: #4c2c92;
-$color__link-blue-active: #1e1e2a;
-$color__link-disabled: #b5c3a8;
-
-$color__focus-blue-outline: #1d70b8;
-$color__cta-background: $color__aqua-blue;
-$color__cta-background-hover: $color__dark-blue;
+$color-almost-black: #121212;
+$color-light-pink: #fbe2bc;
+$color-white: #fff;
+$color-light-grey: #efefef;
+$color-dark-blue: #134571;
+$color-grey: #ddd;
+$color-dark-grey: #555;
+$color-black: #000;
+$color-highlight-blue: #06c;
+$color-yellow: #ffb952;
+$color-aqua-blue: #037091;
+$color-success: #360;
+$color-information: #96d2f8;
+$color-failure: #c30;
+$color-green: #3bb300;
+$color-red: #f00;
+$color-link-blue: $color-aqua-blue;
+$color-link-blue-hover: $color-dark-blue;
+$color-link-blue-focus: $color-dark-blue;
+$color-link-blue-visited: #4c2c92;
+$color-link-blue-active: #1e1e2a;
+$color-link-disabled: #b5c3a8;
+$color-focus-blue-outline: #1d70b8;
+$color-cta-background: $color-aqua-blue;
+$color-cta-background-hover: $color-dark-blue;

--- a/src/includes/variables/_variables.scss
+++ b/src/includes/variables/_variables.scss
@@ -1,26 +1,23 @@
 @import "./colours";
 
-$spacer__unit: 1rem;
-
-$gutter_unit: 25px;
-
-$grid__breakpoint-small: 576px;
-$grid__breakpoint-medium: 768px;
-$grid__breakpoint-large: 992px;
-$grid__breakpoint-extra-large: 1200px;
-
-$font__roboto: "Roboto", sans-serif;
-$font__open-sans: "Open Sans", sans-serif;
-$font__serif: serif;
+$spacer-unit: 1rem;
+$gutter-unit: 25px;
+$grid-breakpoint-small: 576px;
+$grid-breakpoint-medium: 768px;
+$grid-breakpoint-large: 992px;
+$grid-breakpoint-extra-large: 1200px;
+$font-roboto: "Roboto", sans-serif;
+$font-open-sans: "Open Sans", sans-serif;
+$font-serif: serif;
 
 // Paths
-$fa_path: "/static/fontawesome-svgs/";
+$fa-path: "/static/fontawesome-svgs/";
 
 // Images
-$fa_chevron_right: "#{$fa_path}chevron-right.svg";
-$fa_chevron_right_white: "#{$fa_path}chevron-right-white.svg";
-$fa_chevron_right_disabled: "#{$fa_path}chevron-right-disabled.svg";
-$fa_chevron_left: "#{$fa_path}chevron-left.svg";
-$fa_chevron_left_white: "#{$fa_path}chevron-left-white.svg";
-$fa_chevron_left_disabled: "#{$fa_path}chevron-left-disabled.svg";
-$fa_download: "#{$fa_path}download.svg";
+$fa-chevron-right: "#{$fa-path}chevron-right.svg";
+$fa-chevron-right-white: "#{$fa-path}chevron-right-white.svg";
+$fa-chevron-right-disabled: "#{$fa-path}chevron-right-disabled.svg";
+$fa-chevron-left: "#{$fa-path}chevron-left.svg";
+$fa-chevron-left-white: "#{$fa-path}chevron-left-white.svg";
+$fa-chevron-left-disabled: "#{$fa-path}chevron-left-disabled.svg";
+$fa-download: "#{$fa-path}download.svg";


### PR DESCRIPTION
Prettier makes sure that the SCSS is syntactically valid and looks good, but stylelint starts to enforce conventions around writing good SCSS in the first place. It follows the [TNA CSS developer guidelines](https://nationalarchives.github.io/developer-handbook/technology/css/) to enforce things like BEM, and also adds [enforced property grouping/ordering](https://github.com/kutsan/stylelint-config-clean-order).