### PR TITLE
Add disabled link color

### DIFF
--- a/src/includes/variables/_colours.scss
+++ b/src/includes/variables/_colours.scss
@@ -22,6 +22,7 @@ $color__link-blue-hover: $color__dark-blue;
 $color__link-blue-focus: $color__dark-blue;
 $color__link-blue-visited: #4c2c92;
 $color__link-blue-active: #1e1e2a;
+$color__link-disabled: #b5c3a8;
 
 $color__focus-blue-outline: #1d70b8;
 $color__cta-background: $color__aqua-blue;


### PR DESCRIPTION
...matching the grey tone used in the fontawesome icon set for disabled icons. 

This is used in the 'search highlight' toolbar, for when there's not a previous or next match to move to.