### PR TITLE
ensure images in judgments fit within viewport

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -18,6 +18,10 @@
     max-width: 46rem;
   }
 
+  img {
+    max-width: 100vw;
+  }
+
   table {
     border-collapse: collapse;
     width: 100%;


### PR DESCRIPTION
Images that are resized in word have a `style` attribute set by the parser with a width which can overflow the boundaries of the container, and break the page layout on mobile. This stops that happening :-)