### PR TITLE
add overflow-wrap: anywhere to judgments body to fix long lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/ds-caselaw-frontend",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Shared styles for the National Archives Find Case Law project",
   "main": "src/main.scss",
   "scripts": {

--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -219,6 +219,7 @@
   font-family: $font-serif;
   font-size: 1.2rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 
   img {
     max-width: 100vw;


### PR DESCRIPTION
Fixes the issues in:

https://trello.com/c/QkAw4KJC/1734-wide-content-decide-how-to-handle-in-parser
and
https://trello.com/c/9YZtky8E/1772-wide-content-forms-long-horizontal-lines-2024-uksc-9-10

in which long lines with no spaces push the rest of the judgment body out into the horizonatl scroll overflow.

Before:

![Screenshot 2024-03-12 at 13 15 46](https://github.com/nationalarchives/ds-caselaw-frontend/assets/4279/b9fdb0e7-b49a-4a36-b399-25cd4020b6e1)

After:

![Screenshot 2024-03-12 at 13 16 11](https://github.com/nationalarchives/ds-caselaw-frontend/assets/4279/a948f7f2-194c-429e-b091-15a58a1d9e4b)
