### PR TITLE
scroll margin for <sections> that aren't a .judgment_section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/ds-caselaw-frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared styles for the National Archives Find Case Law project",
   "main": "src/main.scss",
   "scripts": {

--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -282,6 +282,10 @@
     }
   }
 
+  section {
+    scroll-margin-top: 4rem;
+  }
+
   &__section {
     scroll-margin-top: 4rem;
 


### PR DESCRIPTION
The new internal document links in the judgment ToC link to `<section>` tags which don't have the .judgment__section class, and therefore don't have the same scroll margin. This adds the appropriate scroll margin to all <sections> in a judgment.