### PR TITLE
Bump version to align with version numbers in tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/ds-caselaw-frontend",
-  "version": "0.1.1",
+  "version": "2.0.2",
   "description": "Shared styles for the National Archives Find Case Law project",
   "main": "src/main.scss",
   "scripts": {


### PR DESCRIPTION
we've been using tags to number versions, without updating the package.json file, when they should probably be kept in sync. This updates the version number in package.json to match the current 'version number' from the tags (plus a bugfix bump for the current feature being released).