### PR TITLE
ci(secrets): add missing secrets workflow

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,11 @@
+name: Source safety
+on:
+  pull_request:
+  push:
+jobs:
+  secrets:
+    name: Check for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main


### PR DESCRIPTION
TNA standards require that this workflow be included to detect committed secrets; make sure it has been added to the repo.