### PR TITLE
[FCL-195] Skip pre-commit branch check in CI

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -10,3 +10,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
The recent changes to pre-commit introduce checks which make sure users aren’t committing to main. Unfortunately when we run pre-commit in CI on main it complains.

Disable this check in the CI workflow, so it remains in place for local runs but is ignored for CI.

## Jira

FCL-195