### PR TITLE
FCL-226 | fix scroll margin for new title in sticky header

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -1,7 +1,7 @@
 @import "./mixins";
 /* stylelint-disable no-descending-specificity */
 @mixin judgment-footnote {
-  scroll-margin-top: 4rem;
+  scroll-margin-top: 9rem;
   padding-bottom: 1rem;
   text-decoration: none;
 
@@ -330,11 +330,11 @@
   }
 
   section {
-    scroll-margin-top: 4rem;
+    scroll-margin-top: 9rem;
   }
 
   &__section {
-    scroll-margin-top: 4rem;
+    scroll-margin-top: 9rem;
 
     @media (max-width: $grid-breakpoint-medium) {
       > div {
@@ -410,7 +410,7 @@
 
 .judgment-footer {
   &__footnote {
-    scroll-margin-top: 4em;
+    scroll-margin-top: 9rem;
   }
 
   &__footnote-backlink {


### PR DESCRIPTION
When we added the title to the sticky header, it made it so when the user clicks an anchor link to a section on the page, the sticky header hides the text being linked to.

This increases the margin so the user can see the title:

<img width="371" alt="image" src="https://github.com/user-attachments/assets/c515961e-d26c-4238-9ff6-1fdca01ac0ec">
