### PR TITLE
FCL-369 | fix nested subsection styling

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -376,6 +376,10 @@
   }
 
   &__nested-section {
+    span {
+      word-wrap: break-word;
+    }
+
     @media (max-width: $grid-breakpoint-medium) {
       margin-left: $space-4;
 
@@ -400,9 +404,17 @@
     }
 
     @media (min-width: $grid-breakpoint-medium) {
-      display: grid;
-      grid-template: ". ." 1fr / 1fr 24fr;
-      gap: 0 $space-2;
+      display: flex;
+      gap: $space-2;
+
+      &:has(span:empty) {
+        gap: 0;
+        margin: 0;
+
+        .judgment-body__number {
+          padding: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Goes from looking like this:

<img width="891" alt="image" src="https://github.com/user-attachments/assets/8ad253b9-76d9-4817-a585-0a46bfe971e6">

To this:

<img width="962" alt="image" src="https://github.com/user-attachments/assets/dd1b7d86-6ccc-4cfd-9eb9-4e98f6bfaba4">

And on mobile before:

<img width="370" alt="image" src="https://github.com/user-attachments/assets/7b897999-d289-4ace-af52-af6744540a12">

After on mobile:

<img width="371" alt="image" src="https://github.com/user-attachments/assets/482f660f-cd30-4d14-95eb-2dee570465e1">
