### PR TITLE
Fix version numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ to ensure your development copy loads the local version of this package.
 
 When you're ready, create a PR on this repository. Once it is merged into main,
 run `npm update` in the two applications to pull the latest `main`, and create PRs for the changes to `package-lock.json`. Once they are merged and deployed, the latest changes will be used.
+
+## Releasing
+
+- Update the version number in `package.json`
+- Tag the new release in GitHub

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nationalarchives/ds-caselaw-frontend",
-  "version": "2.0.4",
+  "version": "2.0.7",
   "description": "Shared styles for the National Archives Find Case Law project",
   "main": "src/main.scss",
   "scripts": {


### PR DESCRIPTION
The version number hasn't been updated correctly in the `package.json` and this is potentially confusing downstream tooling. Update accordingly, and add a note in the README about how this should behave.