### PR TITLE
Fix | only show scrollbars for tables on mobile

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -299,6 +299,7 @@
     margin: $space-4 0;
 
     @media (min-width: $grid-breakpoint-medium) {
+      overflow: visible;
       width: calc(100% + $judgment-margin-offset);
       margin: $space-4 (-$judgment-margin-offset);
     }


### PR DESCRIPTION
For some users who have specifically set their scrollbar settings to always show, they would show for tables on desktop. This change makes it so there are no scrollbars for tables on desktop (and mobile users can continue to scroll)