### PR TITLE
Fcl 768/remove breaking words pr two column

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -327,6 +327,8 @@
   }
 
   &__number {
+    white-space: nowrap;
+
     &:target {
       animation-name: emphasis-border;
       animation-duration: 1.5s;

--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -237,6 +237,7 @@
     &.pr-two-column {
       table-layout: fixed;
       width: 100%;
+      white-space: nowrap;
 
       td:first-child {
         width: 80%;


### PR DESCRIPTION
This fixes some issues with text breaking onto 2 lines where it shouldn't.

Before:

<img width="657" alt="image" src="https://github.com/user-attachments/assets/4b75611e-aeb0-4758-9b6e-f211db71b5df" />

After:


<img width="618" alt="image" src="https://github.com/user-attachments/assets/72433a41-2e21-4dfa-93a6-f26e8441f4d8" />

Before:


<img width="660" alt="image" src="https://github.com/user-attachments/assets/47e87baf-d5c7-492a-9a28-5d65c5c67834" />

After:


<img width="657" alt="image" src="https://github.com/user-attachments/assets/670dfba9-c17a-49e2-b12a-01ee9b69e4c7" />

