### PR TITLE
FCL-858 | fix 2 column header on mobile

### DIFF
--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -259,6 +259,31 @@
           white-space: nowrap;
         }
       }
+
+      @media (max-width: $grid-breakpoint-small) {
+        display: flex;
+
+        tbody {
+          width: 100%;
+
+          tr {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+
+            td,
+            td:first-child,
+            td:last-child {
+              width: 100%;
+              padding: 0;
+
+              .judgment-header__pr-right {
+                text-align: center !important;
+              }
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This fixes the display issues on mobile with 2 column headers.


### Before

<img width="291" alt="image" src="https://github.com/user-attachments/assets/fba78acb-ee21-4274-b7fb-6b2043d2dee8" />


### After

<img width="290" alt="image" src="https://github.com/user-attachments/assets/7c5bd9b7-bd98-4ea4-bdf9-42f4117812b3" />
