### PR TITLE
Get pre-commit running properly in merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 permissions: {}
 on:
+  pull_request:
+    branches: ["main"]
   push:
+    branches: ["main"]
+  merge_group:
+    types: ["checks_requested"]
 
 jobs:
   build-scss:

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -3,6 +3,10 @@ permissions: {}
 on:
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["main"]
+  merge_group:
+    types: ["checks_requested"]
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - run: npm ci
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,13 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
-  - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-    rev: v17.11.0
+  - repo: local
     hooks:
       - id: stylelint
-        args: [--fix]
-        language: node
-        additional_dependencies:
-          - stylelint@17.11.0
-          - stylelint-config-standard-scss@17.0.0
-          - stylelint-config-clean-order@8.0.1
+        name: stylelint
+        entry: npx --no-install stylelint --fix
+        language: system
+        types_or: [scss]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/src/includes/_judgment_text.scss
+++ b/src/includes/_judgment_text.scss
@@ -30,7 +30,7 @@
 
     vertical-align: top;
 
-    background-color: rgba(colour-var("accent-brand"), 0.25);
+    background-color: rgb(colour-var("accent-brand"), 0.25);
   }
 }
 
@@ -338,7 +338,7 @@
     td {
       padding: 0.5rem 0.75rem;
       border: 1px solid colour-var("contrast-background");
-      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
   }
 
@@ -406,7 +406,7 @@
 
   &__nested-section {
     span {
-      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
 
     @media (max-width: $grid-breakpoint-medium) {


### PR DESCRIPTION
Pre-commit hasn't been behaving consistently, and has recently started failing (thanks to a stylelint problem) which haven't been spotted because it hasn't been a required test.

To make it a required test, we need to:

- Make sure it runs in merge queues, or things will be stuck in the queue forever
- Actually get it running

We do the first of these by making sure that our CI and pre-commit workflows have consistent run conditions including on merge queues.

The second of these involves moving to running stylelint via `npx` instead of using pre-commit's isolated environments. This is because stylelint 17 broke pre-commit's isolation behaviour.